### PR TITLE
Blank Installation Screen (Step 2) #1

### DIFF
--- a/functions/PragRepFnc.php
+++ b/functions/PragRepFnc.php
@@ -23,4 +23,3 @@ function par_rep_cb($match='',$exp='',$sub='')
 } 
 
 ?>
-


### PR DESCRIPTION
#1 
The space was the cause of the given issue. Removing the space allows installation to go further.